### PR TITLE
Update info on Inkways

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@
 | 🌟 [SketchNow](#sketchnow) ![GitHub Commit Activity](https://img.shields.io/github/commit-activity/y/SketchNow/SketchNow.WPF?label=) | <picture><source media="(prefers-color-scheme: dark)" srcset="https://images.weserv.nl/?url=github.com/realybin.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=222"><img src="https://images.weserv.nl/?url=github.com/realybin.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=fff" width="20" height="20"/></picture>&nbsp;<a href="https://github.com/realybin">realybin</a> |
 | [ppInk](#ppink) ![GitHub Commit Activity](https://img.shields.io/github/commit-activity/y/pubpub-zz/ppInk?label=) | <picture><source media="(prefers-color-scheme: dark)" srcset="https://images.weserv.nl/?url=github.com/pubpub-zz.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=222"><img src="https://images.weserv.nl/?url=github.com/pubpub-zz.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=fff" width="20" height="20"/></picture>&nbsp;<a href="https://github.com/pubpub-zz">pubpub-zz</a> |
 | [Inkways](#inkways-wip) ![闭源](https://img.shields.io/badge/%E9%97%AD%E6%BA%90-%23ca8a04?style=flat&label=) | <picture><source media="(prefers-color-scheme: dark)" srcset="https://images.weserv.nl/?url=github.com/iNKORE-NET.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=222"><img src="https://images.weserv.nl/?url=github.com/iNKORE-NET.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=fff" width="20" height="20"/></picture>&nbsp;<a href="https://github.com/iNKORE-NET">iNKORE-NET</a> |
-| [~~Inkways Legacy~~](#inkways-legacy) ![闭源](https://img.shields.io/badge/%E9%97%AD%E6%BA%90-%23ca8a04?style=flat&label=) | <picture><source media="(prefers-color-scheme: dark)" srcset="https://images.weserv.nl/?url=github.com/iNKORE-NET.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=222"><img src="https://images.weserv.nl/?url=github.com/iNKORE-NET.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=fff" width="20" height="20"/></picture>&nbsp;<a href="https://github.com/iNKORE-NET">iNKORE-NET</a> |
 | [LemonxNote](#lemonxnote-柠檬白板) ![GitHub Commit Activity](https://img.shields.io/github/commit-activity/y/lh11117/LemonxNote?label=) | <picture><source media="(prefers-color-scheme: dark)" srcset="https://images.weserv.nl/?url=github.com/lh11117.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=222"><img src="https://images.weserv.nl/?url=github.com/lh11117.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=fff" width="20" height="20"/></picture>&nbsp;<a href="https://github.com/lh11117">lh11117</a> |
 | ~~[InkCanvasForClass](#inkcanvasforclass)~~ ![停更](https://img.shields.io/badge/%E5%81%9C%E6%9B%B4-%23b91c1c?style=flat&label=) | <picture><source media="(prefers-color-scheme: dark)" srcset="https://images.weserv.nl/?url=github.com/aloisp28.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=222"><img src="https://images.weserv.nl/?url=github.com/aloisp28.png?v=4&h=64&w=64&fit=cover&mask=circle&maxage=7d&bg=fff" width="20" height="20"/></picture>&nbsp; Dubi906w |
 
@@ -637,19 +636,23 @@ ppInk is a user-friendly on-screen annotation software for Windows, compatible w
 ![专有软件](https://img.shields.io/badge/%E4%B8%93%E6%9C%89%E8%BD%AF%E4%BB%B6-%23dc2626?style=flat&labelColor=%237f1d1d)
 ![Design](https://img.shields.io/badge/iNKO%20Design%20System-9648E9)
 ![Price](https://img.shields.io/badge/price-freemium-green)
-![Platforms](https://img.shields.io/badge/win%20%7C%20mac%20%7C%20linux%20%7C%20android%20%7C%20ios%20%7C%20web-brightgreen?label=supports
+![Platforms](https://img.shields.io/badge/win%20%7C%20linux%20%7C%20android%20%7C%20ios%20%7C%20web-brightgreen?label=supports
 )<br/>
-[![Discord](https://img.shields.io/discord/1092738458805608561?style=social&label=Discord&logo=discord)](https://discord.gg/m6NPNVk4bs)
-[![Telegram](https://img.shields.io/badge/Telegram-Chat-blue?style=social&logo=telegram)](https://t.me/iNKORE)
+[![Discord](https://img.shields.io/discord/1092738458805608561?style=social&label=Discord&logo=discord)](http://www.inkore.net/invito/discord)
+[![Telegram](https://img.shields.io/badge/Telegram-Chat-blue?style=social&logo=telegram)](http://www.inkore.net/invito/telegram-zh)
 [![QQ](https://img.shields.io/badge/-%E4%BA%A4%E6%B5%81%E7%BE%A4%20825759306-white?style=flat&logo=qq)](https://qm.qq.com/q/VMym9nrlim)
 
 </div>
 
 > [!note]
 >
-> 本软件仍在~~画饼~~开发阶段，~~如有需要请先使用 Inkways Legacy~~，或加入社区以获取最新消息。 **最新消息：该软件的开发团队正在维护另一个项目，且团队中的部分成员已经去学习深造了，目前几乎只有一人在维护此项目。（2025年6月14日更新）**
+> 团队目前正集中资源进行基础设施建设和其他项目的开发，同时部分成员正在进行技术深造。预计 2026 年中下旬将启动 Inkways 的全面开发工作。在此期间，您也可以看看推荐列表中其他优秀作品，或[加入我们的社区](https://www.inkore.net/community?topics=inkways&locales=zh-cn)第一时间获取最新动态。
+>
+> 除官方网站及其社交媒体外，任何关于 Inkways的 "小道消息" 均**不可信**；Inkways 不存在绿色版 / Windows XP 特别版等非官方版本；目前没有终身激活的买断计划，任何此类销售**均为诈骗**。请大家理性上网，**不信谣不传谣**！遇到可疑信息请通过[官方验证通道](https://www.inkore.net/imposters)辨认真伪。本公司任何产品都不允许在闲鱼(二次)销售！
+> 
+> *此讯息最后更新于 06/14/2025。*
 
-Inkways 是一款由 iNKORE Studios 开发的集成式墨迹套件，你可以将它用于记录笔记，文稿演示，批注演示文稿，视频展台等。Inkways 旨在将 Ink，Presentation，Flow 等核心概念融合在一起并无缝带入到生活和工作流程的各个角落。
+Inkways 是一款由 iNKORE Studios 开发的集成式墨迹解决方案，你可以将它用于记录笔记，文稿演示，批注演示文稿，视频展台等。Inkways 旨在将 Ink，Presentation，Flow 等核心概念融合在一起并无缝带入到生活和工作流程的各个角落。
 
 更多信息可以在 <https://docs.inkore.net/announcements/2024/03/12/inkways-vanilla-is-on-the-way/> 查看。
 
@@ -657,14 +660,16 @@ Inkways 是一款由 iNKORE Studios 开发的集成式墨迹套件，你可以�
 
 <table align="center">
 <tr>
-    <td><img src="https://github.com/iNKORE-NET.png" width="18" height="18"></td>
-    <td><b>官网 (不可用)</b></td>
-    <td><a href="https://inkore.net/products/inkways/">https://inkore.net/products/inkways/</a></td>
+    <td><img src="https://www.inkore.net/favicon.ico?size=18" width="18" height="18"></td>
+    <td><b>官网</b></td>
+    <td><a href="https://inkore.net/products/inkways">inkore.net/inkways</a></td>
 </tr>
 <tr>
     <td><img src="images/github-icon.svg" width="18" height="18"></td>
     <td><b>开发者</b></td>
-    <td><img src="https://github.com/iNKORE-NET.png" width="20" height="20"/> <a href="https://github.com/iNKORE-NET/">iNKORE Studios</a></td>
+    <td>
+      <a href="https://github.com/iNKORE-NET/">@iNKORE-NET</a>
+    </td>
 </tr>
 </table>
 
@@ -672,50 +677,6 @@ Inkways 是一款由 iNKORE Studios 开发的集成式墨迹套件，你可以�
 
 <br/>
 <br/>
-
-<img src="images/inkways-classic-icon.png" width="56" height="56"/> 
-
-### Inkways Legacy
-
-![专有软件](https://img.shields.io/badge/%E4%B8%93%E6%9C%89%E8%BD%AF%E4%BB%B6-%23dc2626?style=flat&labelColor=%237f1d1d)
-![Design](https://img.shields.io/badge/Fluent%20Design%20System-003E92)
-![Price](https://img.shields.io/badge/price-free-green)
-![Platforms](https://img.shields.io/badge/win-green?label=supports
-)<br/>
-[![Discord](https://img.shields.io/discord/1092738458805608561?style=social&label=Discord&logo=discord)](https://discord.gg/m6NPNVk4bs)
-[![Telegram](https://img.shields.io/badge/Telegram-Chat-blue?style=social&logo=telegram)](https://t.me/iNKORE)
-[![交流群](https://img.shields.io/badge/-%E4%BA%A4%E6%B5%81%E7%BE%A4%20825759306-white?style=flat&logo=qq)](https://qm.qq.com/q/VMym9nrlim)
-
-</div>
-
->Inkways Legacy已死，有事也别烧纸，等明年新Inkways开工吧
-
-完全契合 Windows 11 风格的，轻量但全能并适用于教学场景的墨迹套件。支持插入文本图片，模拟和原生压感，撤消重做，多页文档... 本套件包含笔记，画板，桌面画笔和 PowerPoint 助手。
-
-🏷 **关键词**：`Fluent Design System` `多插件` `多功能套件` `笔记`
-
-💬 **Dubi906w 锐评**：总体不如 Ink Canvas 系列，可以尝试一下，UI 设计比较好看，但是有部分功能还未完善，希望有生之年能看见新版 Inkways 出来。
-
-💬 **Aris 锐评**：u1s1 尝鲜可以，但是不建议在学校长期使用，还不如等新版 Inkways。
-
-<table align="center">
-<tr>
-    <td><img src="https://github.com/iNKORE-NET.png" width="18" height="18"></td>
-    <td><b>官网 (不可用)</b></td>
-    <td><a href="https://inkore.net/products/inkways/">https://inkore.net/products/inkways/</a></td>
-</tr>
-<tr>
-    <td><img src="images/github-icon.svg" width="18" height="18"></td>
-    <td><b>开发者</b></td>
-    <td><img src="https://github.com/iNKORE-NET.png" width="20" height="20"/> <a href="https://github.com/iNKORE-NET/">iNKORE Studios</a></td>
-</tr>
-</table>
-
-<div align="center">
-
-<br/>
-<br/>
-
 
 
 <img src="https://github.com/InkCanvas/InkCanvasForClass/raw/master/icc.png" width="56" height="56"/> 


### PR DESCRIPTION
1. Removed 'inkways-legacy'
2. Updated website status 'unavailable' to ''
3. Removed macOS support for Inkways
4. Refined coming-soon message
5. Added imposter warning
6. Update broken/outdated links